### PR TITLE
Implement PHPStan extension to get better static analysis support for the `scoped` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,18 @@ class Admin extends Model
     use ScopesActive;
 }
 ```
+
+## PHPStan extension
+
+You can use the PHPStan extension to get better static analysis support for the `scoped` method.
+
+To enable the extension, you need to include it in the `phpstan.neon` configuration file as follows:
+
+```yaml
+includes:
+    - vendor/mpyw/laravel-local-class-scope/extension.neon
+    - vendor/larastan/larastan/extension.neon
+```
+
+> [!IMPORTANT]
+> If you are using [Larastan](https://github.com/larastan/larastan) (as is typical), you must include the extension of this package **before** Larastan's extension.

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "App\\": "tests/application/app/",
             "Mpyw\\LaravelLocalClassScope\\Tests\\": "tests/"
         }
     },
@@ -26,9 +27,12 @@
         "illuminate/support": "^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
+        "headercat/phpstan-extension-ide-helper": "^2.1",
+        "larastan/larastan": "^3.9",
         "orchestra/testbench": "*",
         "orchestra/testbench-core": ">=9.0",
-        "phpunit/phpunit": ">=11.0"
+        "phpunit/phpunit": ">=11.0",
+        "phpstan/phpstan": "^2.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: Mpyw\LaravelLocalClassScope\PHPStan\Reflection\ScopedMacroExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,12 @@
+includes:
+    - extension.neon
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+    level: max
+    paths:
+        - src
+        - tests
+    excludePaths:
+        - tests/PHPStan/Integration/data
+        - tests/PHPStan/Reflection/data

--- a/src/PHPStan/Reflection/ScopedMacroExtension.php
+++ b/src/PHPStan/Reflection/ScopedMacroExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelLocalClassScope\PHPStan\Reflection;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Override;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+
+final class ScopedMacroExtension implements MethodsClassReflectionExtension
+{
+    #[Override]
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if ($methodName !== 'scoped') {
+            return false;
+        }
+
+        return $classReflection->is(Model::class) || $classReflection->is(Builder::class);
+    }
+
+    #[Override]
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        if ($classReflection->is(Model::class)) {
+            // Model::scoped()
+            $modelType = new ObjectType($classReflection->getName());
+            $isStatic  = true;
+        } else {
+            // Builder::scoped()
+            $templateMap = $classReflection->getActiveTemplateTypeMap();
+            $modelType   = $templateMap->getType('TModel');
+
+            if ($modelType === null) {
+                $modelType = new ObjectType(Model::class);
+            }
+
+            $isStatic = false;
+        }
+
+        $builderType = new GenericObjectType(
+            Builder::class,
+            [$modelType],
+        );
+
+        return new ScopedMethodReflection(
+            $classReflection,
+            $builderType,
+            $isStatic,
+        );
+    }
+}

--- a/src/PHPStan/Reflection/ScopedMethodReflection.php
+++ b/src/PHPStan/Reflection/ScopedMethodReflection.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelLocalClassScope\PHPStan\Reflection;
+
+use Illuminate\Database\Eloquent\Scope;
+use Override;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+final class ScopedMethodReflection implements MethodReflection
+{
+    public function __construct(
+        private readonly ClassReflection $declaringClass,
+        private readonly Type $returnType,
+        private readonly bool $isStatic,
+    ) {}
+
+    #[Override]
+    public function getName(): string
+    {
+        return 'scoped';
+    }
+
+    #[Override]
+    public function getPrototype(): MethodReflection
+    {
+        return $this;
+    }
+
+    #[Override]
+    public function getVariants(): array
+    {
+        return [
+            new FunctionVariant(
+                TemplateTypeMap::createEmpty(),
+                null,
+                [
+                    new ScopedParameterReflection(
+                        'scope',
+                        new UnionType([
+                            new ObjectType(Scope::class),
+                            new GenericClassStringType(
+                                new ObjectType(Scope::class),
+                            ),
+                        ]),
+                        false,
+                        false,
+                    ),
+                    new ScopedParameterReflection(
+                        'parameters',
+                        new MixedType,
+                        true,
+                        true,
+                    ),
+                ],
+                true,
+                $this->returnType,
+            ),
+        ];
+    }
+
+    #[Override]
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    #[Override]
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    #[Override]
+    public function isFinal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    #[Override]
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    #[Override]
+    public function getThrowType(): ?Type
+    {
+        return null;
+    }
+
+    #[Override]
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return TrinaryLogic::createYes();
+    }
+
+    #[Override]
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->declaringClass;
+    }
+
+    #[Override]
+    public function isStatic(): bool
+    {
+        return $this->isStatic;
+    }
+
+    #[Override]
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    #[Override]
+    public function getDocComment(): ?string
+    {
+        return null;
+    }
+}

--- a/src/PHPStan/Reflection/ScopedParameterReflection.php
+++ b/src/PHPStan/Reflection/ScopedParameterReflection.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelLocalClassScope\PHPStan\Reflection;
+
+use Override;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\Type;
+
+final class ScopedParameterReflection implements ParameterReflection
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly Type $type,
+        private readonly bool $isOptional,
+        private readonly bool $isVariadic,
+    ) {}
+
+    #[Override]
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    #[Override]
+    public function isOptional(): bool
+    {
+        return $this->isOptional;
+    }
+
+    #[Override]
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
+    #[Override]
+    public function passedByReference(): PassedByReference
+    {
+        return PassedByReference::createNo();
+    }
+
+    #[Override]
+    public function isVariadic(): bool
+    {
+        return $this->isVariadic;
+    }
+
+    #[Override]
+    public function getDefaultValue(): ?Type
+    {
+        return null;
+    }
+}

--- a/tests/PHPStan/Integration/IntegrationTest.php
+++ b/tests/PHPStan/Integration/IntegrationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use Override;
+use PHPStan\Analyser\Analyser;
+use PHPStan\Analyser\Error;
+use PHPStan\File\FileHelper;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Throwable;
+
+final class IntegrationTest extends PHPStanTestCase
+{
+    /**
+     * @return iterable<array{0: string, 1?: array<int, string[]>}>
+     */
+    public static function dataIntegrationTests(): iterable
+    {
+        self::getContainer();
+
+        yield [
+            __DIR__.'/data/scoped-usage.php',
+            [
+                11 => [],
+                14 => [],
+                18 => [],
+                22 => [],
+                25 => [],
+                28 => [],
+                31 => ['Parameter #1 $scope of static method App\Models\User::scoped() expects class-string<Illuminate\Database\Eloquent\Scope>|Illuminate\Database\Eloquent\Scope, string given.'],
+                34 => ['Parameter #1 $scope of static method App\Models\User::scoped() expects class-string<Illuminate\Database\Eloquent\Scope>|Illuminate\Database\Eloquent\Scope, stdClass given.'],
+                37 => ['Parameter #1 $scope of static method App\Models\User::scoped() expects class-string<Illuminate\Database\Eloquent\Scope>|Illuminate\Database\Eloquent\Scope, string given.'],
+                40 => ['Parameter #1 $scope of static method App\Models\User::scoped() expects class-string<Illuminate\Database\Eloquent\Scope>|Illuminate\Database\Eloquent\Scope, int given.'],
+                43 => ['Static method App\Models\User::scoped() invoked with 0 parameters, at least 1 required.'],
+            ],
+        ];
+    }
+
+    /**
+     * @param  ?array<int, string[]>  $expectedErrors
+     * @param  string[]  $additionalFiles
+     *
+     * @throws Throwable
+     */
+    #[DataProvider('dataIntegrationTests')]
+    public function test_integration(string $file, ?array $expectedErrors = null, array $additionalFiles = []): void
+    {
+        $errors = $this->runAnalyse($file, additionalFiles: $additionalFiles);
+
+        if ($expectedErrors === null) {
+            $this->assertNoErrors($errors);
+        } else {
+            if (count($expectedErrors) > 0) {
+                $this->assertNotEmpty($errors);
+            }
+
+            $this->assertSameErrorMessages($file, $expectedErrors, $errors);
+        }
+    }
+
+    /**
+     * @see https://github.com/phpstan/phpstan-src/blob/c9772621c0bd6eab7e02fdaa03714bea239b372d/tests/PHPStan/Analyser/AnalyserIntegrationTest.php#L604-L622
+     * @see https://github.com/phpstan/phpstan/discussions/6888#discussioncomment-2423613
+     *
+     * @param  ?string[]  $allAnalysedFiles
+     * @param  string[]  $additionalFiles
+     * @return Error[]
+     *
+     * @throws Throwable
+     */
+    private function runAnalyse(string $file, ?array $allAnalysedFiles = null, array $additionalFiles = []): array
+    {
+        $files = array_map(
+            fn (string $file): string => $this->getFileHelper()->normalizePath($file),
+            [$file, ...$additionalFiles],
+        );
+
+        /** @var Analyser $analyser */
+        // @phpstan-ignore phpstanApi.classConstant
+        $analyser = self::getContainer()->getByType(Analyser::class);
+
+        /** @var FileHelper $fileHelper */
+        $fileHelper = self::getContainer()->getByType(FileHelper::class);
+
+        // @phpstan-ignore phpstanApi.method, phpstanApi.method
+        $errors = $analyser->analyse($files, null, null, true, $allAnalysedFiles)->getErrors();
+
+        foreach ($errors as $error) {
+            $this->assertSame($fileHelper->normalizePath($file), $error->getFilePath());
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<int, string[]>  $expectedErrors
+     * @param  Error[]  $errors
+     */
+    private function assertSameErrorMessages(string $file, array $expectedErrors, array $errors): void
+    {
+        foreach ($errors as $error) {
+            $errorLine = $error->getLine() ?? 0;
+
+            $this->assertArrayHasKey(
+                $errorLine,
+                $expectedErrors,
+                sprintf('File %s has unexpected error "%s" at line %d.', $file, $error->getMessage(), $errorLine),
+            );
+            $this->assertContains(
+                $error->getMessage(),
+                $expectedErrors[$errorLine],
+                sprintf("File %s has unexpected error \"%s\" at line %d.\n\nExpected \"%s\"", $file, $error->getMessage(), $errorLine, implode("\n\t", $expectedErrors[$errorLine])),
+            );
+        }
+    }
+
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__.'/../../../phpstan.neon.dist',
+        ];
+    }
+}

--- a/tests/PHPStan/Integration/data/scoped-usage.php
+++ b/tests/PHPStan/Integration/data/scoped-usage.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Scopes\ActiveScope;
+use App\Models\Scopes\AgeScope;
+use App\Models\User;
+use stdClass;
+
+// 1. Static call: User::scoped(ActiveScope::class) -> No errors
+User::scoped(ActiveScope::class);
+
+// 2. Static call: User::scoped(new ActiveScope) -> No errors
+User::scoped(new ActiveScope);
+
+// 3. Instance call: $user->scoped(ActiveScope::class) -> No errors
+$user = new User;
+$user->scoped(ActiveScope::class);
+
+// 4. Instance call: $user->scoped(new ActiveScope) -> No errors
+$user = new User;
+$user->scoped(new ActiveScope);
+
+// 5. Query builder chaining: User::query()->scoped(ActiveScope::class) -> No errors
+User::query()->scoped(ActiveScope::class);
+
+// 6. Method chaining: User::scoped(ActiveScope::class)->scoped(AgeScope::class, '>=', 18) -> No errors
+User::scoped(ActiveScope::class)->scoped(AgeScope::class, '>=', 18);
+
+// 7. Invalid class: User::scoped(stdClass::class) -> argument.type error
+User::scoped(stdClass::class);
+
+// 8. Invalid class: User::scoped(new stdClass) -> argument.type error
+User::scoped(new stdClass);
+
+// 9. Invalid scalar: User::scoped('invalid scope name') -> argument.type error
+User::scoped('invalid scope name');
+
+// 10. Invalid scalar: User::scoped(123) -> argument.type error
+User::scoped(123);
+
+// 11. No arguments: User::scoped() -> arguments.count error
+User::scoped();

--- a/tests/PHPStan/Reflection/ScopedMacroExtensionTest.php
+++ b/tests/PHPStan/Reflection/ScopedMacroExtensionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelLocalClassScope\Tests\PHPStan\Reflection;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class ScopedMacroExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__.'/data/scoped-macro-inference.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function test_file_asserts(
+        string $assertType,
+        string $file,
+        mixed ...$args,
+    ): void {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__.'/../../../extension.neon',
+        ];
+    }
+}

--- a/tests/PHPStan/Reflection/data/scoped-macro-inference.php
+++ b/tests/PHPStan/Reflection/data/scoped-macro-inference.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Scopes\ActiveScope;
+use App\Models\Scopes\AgeScope;
+use App\Models\User;
+
+use function PHPStan\Testing\assertType;
+
+function test(): void
+{
+    // 1. Static call: User::scoped(ActiveScope::class) -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::scoped(ActiveScope::class),
+    );
+
+    // 2. Static call: User::scoped(new ActiveScope) -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::scoped(new ActiveScope),
+    );
+
+    // 3. Instance call: $user->scoped(ActiveScope::class) -> Builder<User>
+    $user = new User;
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        $user->scoped(ActiveScope::class),
+    );
+
+    // 4. Instance call: $user->scoped(new ActiveScope) -> Builder<User>
+    $user = new User;
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        $user->scoped(new ActiveScope),
+    );
+
+    // 5. Query builder chaining: User::query()->scoped(ActiveScope::class) -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::query()->scoped(ActiveScope::class),
+    );
+
+    // 6. Method chaining: User::scoped(ActiveScope::class)->scoped(AgeScope::class, '>=', 18) -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::scoped(ActiveScope::class)->scoped(AgeScope::class, '>=', 18),
+    );
+
+    // 7. Invalid class: User::scoped(stdClass::class) -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::scoped(stdClass::class),
+    );
+
+    // 8. Invalid class: User::scoped(new stdClass) -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::scoped(new stdClass),
+    );
+
+    // 9. Invalid scalar: User::scoped('invalid scope name') -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::scoped('invalid scope name'),
+    );
+
+    // 10. Invalid scalar: User::scoped(123) -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::scoped(123),
+    );
+
+    // 11. No arguments: User::scoped() -> Builder<User>
+    assertType(
+        'Illuminate\Database\Eloquent\Builder<App\Models\User>',
+        User::scoped(),
+    );
+}

--- a/tests/application/app/Models/Scopes/ActiveScope.php
+++ b/tests/application/app/Models/Scopes/ActiveScope.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Override;
+
+class ActiveScope implements Scope
+{
+    #[Override]
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('active', true);
+    }
+}

--- a/tests/application/app/Models/Scopes/AgeScope.php
+++ b/tests/application/app/Models/Scopes/AgeScope.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Override;
+
+class AgeScope implements Scope
+{
+    /**
+     * @var mixed[]
+     */
+    protected array $parameters;
+
+    public function __construct(mixed ...$parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    #[Override]
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('age', ...$this->parameters);
+    }
+}

--- a/tests/application/app/Models/User.php
+++ b/tests/application/app/Models/User.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model {}


### PR DESCRIPTION
This PR implements a PHPStan extension to get better static analysis support for the `scoped` method.

Currently, the return type is inferred as `mixed`, but this extension resolves it to the specific Builder type (e.g., `Illuminate\Database\Eloquent\Builder<App\Models\User>`).

It also enforces type on the `$scope` argument, accepting only `class-string<Illuminate\Database\Eloquent\Scope>` or `Illuminate\Database\Eloquent\Scope` instances.